### PR TITLE
Landon/mod get force

### DIFF
--- a/Source/MacProj.cpp
+++ b/Source/MacProj.cpp
@@ -679,7 +679,7 @@ MacProj::mac_sync_compute (int                   level,
                 const auto gbx = Smfi.growntilebox(ns_level.nghost_force());
 
                 ns_level.getForce(forcing_term[Smfi],gbx,0,NUM_STATE,
-                                  prev_time,Smf[Smfi],Smf[Smfi],Density);
+                                  prev_time,Smf[Smfi],Smf[Smfi],Density,Smfi);
             }
         }
 

--- a/Source/NS_getForce.cpp
+++ b/Source/NS_getForce.cpp
@@ -31,7 +31,8 @@ NavierStokesBase::getForce (FArrayBox&       force,
                             const Real       time,
                             const FArrayBox& Vel,
                             const FArrayBox& Scal,
-                            int              scalScomp)
+                            int              scalScomp,
+                            const MFIter&    mfi)
 {
 
    const Real* VelDataPtr  = Vel.dataPtr();

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -822,7 +822,7 @@ NavierStokes::scalar_advection (Real dt,
                     }
 
                     getForce(forcing_term[S_mfi],force_bx,fscalar,num_scalars,
-                             prev_time,Umf[S_mfi],Smf[S_mfi],0);
+                             prev_time,Umf[S_mfi],Smf[S_mfi],0,S_mfi);
 
                     for (int n=0; n<num_scalars; ++n)
                     {

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -841,6 +841,10 @@ public:
 
 #ifdef AMREX_PARTICLES
   //
+  // Check in case different particle methods are being used
+  //
+  static bool do_nspc;
+  //
   // Put particle info in plotfile (using ParticleContainer::Checkpoint)?
   //
   static bool particles_in_plotfile;

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -250,7 +250,8 @@ public:
                            const amrex::Real       time,
                            const amrex::FArrayBox& Vel,
                            const amrex::FArrayBox& Scal,
-                           int                     scalScomp);
+                           int                     scalScomp,
+                           const amrex::MFIter&    mfi);
     //
     amrex::FluxRegister& getAdvFluxReg () {
         BL_ASSERT(advflux_reg);

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -1308,7 +1308,7 @@ NavierStokesBase::estTimeStep ()
            amrex::Print() << "---" << '\n'
                           << "H - est Time Step:" << '\n'
                           << "Calling getForce..." << '\n';
-       getForce(tforces_fab,bx,0,AMREX_SPACEDIM,cur_time,S_new[mfi],S_new[mfi],Density);
+       getForce(tforces_fab,bx,0,AMREX_SPACEDIM,cur_time,S_new[mfi],S_new[mfi],Density,mfi);
 
        const auto& rho   = rho_ctime.array(mfi);
        const auto& gradp = Gp.array(mfi);
@@ -2850,7 +2850,7 @@ NavierStokesBase::scalar_advection_update (Real dt,
                tforces.resize(bx,1);
 	       // tforces protected from early destruction by Gpu::synchronize at end of loop.
 	       // so no elixir needed
-               getForce(tforces,bx,sigma,1,halftime,Vel_fab,Scal,0);
+               getForce(tforces,bx,sigma,1,halftime,Vel_fab,Scal,0,Rho_mfi);
 
 	       const auto& Snew = S_new[Rho_mfi].array(sigma);
 	       const auto& Sold = S_old[Rho_mfi].const_array(sigma);
@@ -3434,7 +3434,7 @@ NavierStokesBase::velocity_advection (Real dt)
                                        << "Calling getForce..." << '\n';
                     }
                     getForce(forcing_term[U_mfi],force_bx,Xvel,AMREX_SPACEDIM,
-                             prev_time,Umf[U_mfi],Smf[U_mfi],0);
+                             prev_time,Umf[U_mfi],Smf[U_mfi],0,U_mfi);
 
                     //
                     // Compute the total forcing.
@@ -3667,7 +3667,7 @@ NavierStokesBase::velocity_advection_update (Real dt)
         const Real half_time = 0.5*(state[State_Type].prevTime()+state[State_Type].curTime());
         tforces.resize(bx,AMREX_SPACEDIM);
         Elixir tf_i = tforces.elixir();
-        getForce(tforces,bx,Xvel,AMREX_SPACEDIM,half_time,VelFAB,ScalFAB,0);
+        getForce(tforces,bx,Xvel,AMREX_SPACEDIM,half_time,VelFAB,ScalFAB,0,mfi);
 
         //
         // Do following only at initial iteration--per JBB.
@@ -3778,7 +3778,7 @@ NavierStokesBase::initial_velocity_diffusion_update (Real dt)
                                << "G - initial velocity diffusion update:" << '\n'
                                << "Calling getForce..." << '\n';
             }
-            getForce(tforces_fab,bx,Xvel,AMREX_SPACEDIM,prev_time,U_old[mfi],U_old[mfi],Density);
+            getForce(tforces_fab,bx,Xvel,AMREX_SPACEDIM,prev_time,U_old[mfi],U_old[mfi],Density,mfi);
         }
 
         //
@@ -4623,7 +4623,7 @@ NavierStokesBase::predict_velocity (Real  dt)
                    Print() << "---\nA - Predict velocity:\n Calling getForce...\n";
                }
 
-               getForce(forcing_term[U_mfi],gbx,Xvel,AMREX_SPACEDIM,prev_time,Ufab,Smf[U_mfi],0);
+               getForce(forcing_term[U_mfi],gbx,Xvel,AMREX_SPACEDIM,prev_time,Ufab,Smf[U_mfi],0,U_mfi);
 
                //
                // Compute the total forcing.

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -173,6 +173,7 @@ namespace
 }
 
 #ifdef AMREX_PARTICLES
+bool NavierStokesBase::do_nspc = true;
 bool NavierStokesBase::particles_in_plotfile = false;
 
 namespace
@@ -3938,6 +3939,11 @@ NavierStokesBase::read_particle_params ()
 {
     ParmParse ppp("particles");
     //
+    // Ensure other particle methods aren't being used, like sprays
+    //
+    ppp.query("do_nspc_particles", do_nspc);
+    if (!do_nspc) return;
+    //
     // The directory in which to store timestamp files.
     //
     ppp.query("timestamp_dir", timestamp_dir);
@@ -4007,7 +4013,7 @@ NavierStokesBase::initParticleData ()
 void
 NavierStokesBase::post_restart_particle ()
 {
-    if (level == 0)
+    if (level == 0 && do_nspc)
     {
         BL_ASSERT(NSPC == 0);
 
@@ -4132,7 +4138,7 @@ NavierStokesBase::ParticleDerive (const std::string& name,
 				  Real               time,
 				  int                ngrow)
 {
-    if (name == "particle_count" || name == "total_particle_count") {
+    if ((name == "particle_count" || name == "total_particle_count") && do_nspc) {
 	int ncomp = 1;
 	const DeriveRec* rec = derive_lst.get(name);
 	if (rec)


### PR DESCRIPTION
The MFIter is added as an input to the getForce routine so that member source data can be properly accessed. There are also checks to prevent the usage of the NSPC particle methods from being used for when sprays are brought into PeleLM.